### PR TITLE
Fix scroll jank & Page overflow

### DIFF
--- a/components/Lead/Lead.module.css
+++ b/components/Lead/Lead.module.css
@@ -3,7 +3,7 @@
 }
 
 .lead {
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/components/PerfectGrip/PerfectGrip.module.css
+++ b/components/PerfectGrip/PerfectGrip.module.css
@@ -1,7 +1,7 @@
 .root {
   height: 300vh;
   position: relative;
-  width: 100vw;
+  width: 100%;
   overflow: hidden;
 }
 

--- a/components/PerfectGrip/PerfectGrip.tsx
+++ b/components/PerfectGrip/PerfectGrip.tsx
@@ -21,6 +21,12 @@ function getFilename(i: number) {
 gsap.registerPlugin(useGSAP);
 gsap.registerPlugin(ScrollTrigger);
 
+// iOS has various bugs around scroll positions in combination with ScrollTrigger.
+// That results in jank when you scroll the page quickly and this fixes it.
+ScrollTrigger.normalizeScroll({
+  type: "touch",
+});
+
 function useHeight() {
   const { height, width } = useWindowSize();
   const cachedHeight = useRef(height);
@@ -57,9 +63,9 @@ export default function PerfectGrip() {
         console.error("Canvas context not found");
         return;
       }
+      oldFrame.current = newFrame;
       window.requestAnimationFrame(() => {
         ctx.drawImage(images[newFrame], 0, 0, (height / 2343) * 1920, height);
-        oldFrame.current = newFrame;
       });
     },
     [oldFrame, canvas, height],
@@ -108,13 +114,13 @@ export default function PerfectGrip() {
           { frame: 0 },
           {
             frame: 59,
-            duration: 1.5,
+            duration: 1.25,
           },
           0.25,
         )
         .fromTo(
           playhead,
-          { frame: 59 },
+          { frame: 60 },
           {
             frame: SEQUENCE_LENGTH - 1,
             duration: 1.5,
@@ -135,7 +141,7 @@ export default function PerfectGrip() {
             opacity: 0,
             duration: 0.25,
           },
-          1.35,
+          1.25,
         );
     },
     {


### PR DESCRIPTION
* Fixes an horizontal overflow on desktop. It was caused by the usage of `100vw`.
* Fixes animation jank by avoiding overlapping animations (1.25+0.25 = 1.5), and avoiding a repeat of the 59th frame.
* Fixes scroll jank on iOS by using `ScrollTrigger.normalizeScroll`.
* Avoids scheduling another `requestAnimationFrame` with the same frame number.